### PR TITLE
Use flag to prevent errors when no Windows files found

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -38,8 +38,8 @@ install_elasticsearch() {
     cd $(untar_path $install_type $version $tmp_download_dir)
 
     # Remove windows related files
-    find . -name "*.exe" -print0 | xargs -0 rm
-    find . -name "*.bat" -print0 | xargs -0 rm
+    find . -name "*.exe" -print0 | xargs -r0 rm
+    find . -name "*.bat" -print0 | xargs -r0 rm
 
     mv ./* $ASDF_INSTALL_PATH || exit 1
   )


### PR DESCRIPTION
Not all versions of the Elasticsearch source contain .exe or .bat files (for example, 7.1.1 has .exe but not .bat). The rm command fails in these cases since it's given no arguments. 

This uses the -r flag to prevent xargs from running the command if given no arguments. Works great on Linux. However, I'm not sure if this will work with the BSD xargs that comes on OSX, because the man page describes -r as "This option is a GNU extension."